### PR TITLE
[Feat] Notion Authorization with Rocket.Chat

### DIFF
--- a/NotionApp.ts
+++ b/NotionApp.ts
@@ -7,8 +7,10 @@ import {
 import { App } from "@rocket.chat/apps-engine/definition/App";
 import { IAppInfo } from "@rocket.chat/apps-engine/definition/metadata";
 import { settings } from "./config/settings";
+import { OAuth2Client } from "./src/authorization/OAuth2Client";
 
 export class NotionApp extends App {
+    private oAuth2Client: OAuth2Client;
     constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
         super(info, logger, accessors);
     }
@@ -22,5 +24,11 @@ export class NotionApp extends App {
                 configurationExtend.settings.provideSetting(setting);
             })
         );
+
+        this.oAuth2Client = new OAuth2Client(this);
+    }
+
+    public getOAuth2Client(): OAuth2Client {
+        return this.oAuth2Client;
     }
 }

--- a/NotionApp.ts
+++ b/NotionApp.ts
@@ -14,6 +14,11 @@ import { settings } from "./config/settings";
 import { OAuth2Client } from "./src/authorization/OAuth2Client";
 import { NotionCommand } from "./src/commands/NotionCommand";
 import { NotionSDK } from "./src/lib/NotionSDK";
+import {
+    ApiSecurity,
+    ApiVisibility,
+} from "@rocket.chat/apps-engine/definition/api";
+import { WebHookEndpoint } from "./src/endpoints/webhook";
 import { ElementBuilder } from "./src/lib/ElementBuilder";
 import { BlockBuilder } from "./src/lib/BlockBuilder";
 import {
@@ -45,6 +50,12 @@ export class NotionApp extends App {
                 configurationExtend.settings.provideSetting(setting);
             })
         );
+
+        await configurationExtend.api.provideApi({
+            visibility: ApiVisibility.PUBLIC,
+            security: ApiSecurity.UNSECURE,
+            endpoints: [new WebHookEndpoint(this)],
+        });
 
         this.oAuth2Client = new OAuth2Client(this);
         this.NotionSdk = new NotionSDK();

--- a/NotionApp.ts
+++ b/NotionApp.ts
@@ -1,12 +1,26 @@
 import {
     IAppAccessors,
+    IConfigurationExtend,
+    IEnvironmentRead,
     ILogger,
 } from "@rocket.chat/apps-engine/definition/accessors";
 import { App } from "@rocket.chat/apps-engine/definition/App";
 import { IAppInfo } from "@rocket.chat/apps-engine/definition/metadata";
+import { settings } from "./config/settings";
 
 export class NotionApp extends App {
     constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
         super(info, logger, accessors);
+    }
+
+    public async initialize(
+        configurationExtend: IConfigurationExtend,
+        environmentRead: IEnvironmentRead
+    ): Promise<void> {
+        await Promise.all(
+            settings.map((setting) => {
+                configurationExtend.settings.provideSetting(setting);
+            })
+        );
     }
 }

--- a/NotionApp.ts
+++ b/NotionApp.ts
@@ -8,6 +8,7 @@ import { App } from "@rocket.chat/apps-engine/definition/App";
 import { IAppInfo } from "@rocket.chat/apps-engine/definition/metadata";
 import { settings } from "./config/settings";
 import { OAuth2Client } from "./src/authorization/OAuth2Client";
+import { NotionCommand } from "./src/commands/NotionCommand";
 
 export class NotionApp extends App {
     private oAuth2Client: OAuth2Client;
@@ -19,6 +20,9 @@ export class NotionApp extends App {
         configurationExtend: IConfigurationExtend,
         environmentRead: IEnvironmentRead
     ): Promise<void> {
+        await configurationExtend.slashCommands.provideSlashCommand(
+            new NotionCommand(this)
+        );
         await Promise.all(
             settings.map((setting) => {
                 configurationExtend.settings.provideSetting(setting);

--- a/NotionApp.ts
+++ b/NotionApp.ts
@@ -58,7 +58,7 @@ export class NotionApp extends App {
         });
 
         this.oAuth2Client = new OAuth2Client(this);
-        this.NotionSdk = new NotionSDK();
+        this.NotionSdk = new NotionSDK(this.getAccessors().http);
         this.elementBuilder = new ElementBuilder(this.getID());
         this.blockBuilder = new BlockBuilder(this.getID());
     }

--- a/NotionApp.ts
+++ b/NotionApp.ts
@@ -10,10 +10,15 @@ import { settings } from "./config/settings";
 import { OAuth2Client } from "./src/authorization/OAuth2Client";
 import { NotionCommand } from "./src/commands/NotionCommand";
 import { NotionSDK } from "./src/lib/NotionSDK";
+import { ElementBuilder } from "./src/lib/ElementBuilder";
+import { BlockBuilder } from "./src/lib/BlockBuilder";
+import { IAppUtils } from "./definition/lib/IAppUtils";
 
 export class NotionApp extends App {
     private oAuth2Client: OAuth2Client;
     private NotionSdk: NotionSDK;
+    private elementBuilder: ElementBuilder;
+    private blockBuilder: BlockBuilder;
     constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
         super(info, logger, accessors);
     }
@@ -33,14 +38,18 @@ export class NotionApp extends App {
 
         this.oAuth2Client = new OAuth2Client(this);
         this.NotionSdk = new NotionSDK();
+        this.elementBuilder = new ElementBuilder(this.getID());
+        this.blockBuilder = new BlockBuilder(this.getID());
     }
 
     public getOAuth2Client(): OAuth2Client {
         return this.oAuth2Client;
     }
-    public getUtils() {
+    public getUtils(): IAppUtils {
         return {
             NotionSdk: this.NotionSdk,
+            elementBuilder: this.elementBuilder,
+            blockBuilder: this.blockBuilder,
         };
     }
 }

--- a/NotionApp.ts
+++ b/NotionApp.ts
@@ -9,9 +9,11 @@ import { IAppInfo } from "@rocket.chat/apps-engine/definition/metadata";
 import { settings } from "./config/settings";
 import { OAuth2Client } from "./src/authorization/OAuth2Client";
 import { NotionCommand } from "./src/commands/NotionCommand";
+import { NotionSDK } from "./src/lib/NotionSDK";
 
 export class NotionApp extends App {
     private oAuth2Client: OAuth2Client;
+    private NotionSdk: NotionSDK;
     constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
         super(info, logger, accessors);
     }
@@ -30,9 +32,15 @@ export class NotionApp extends App {
         );
 
         this.oAuth2Client = new OAuth2Client(this);
+        this.NotionSdk = new NotionSDK();
     }
 
     public getOAuth2Client(): OAuth2Client {
         return this.oAuth2Client;
+    }
+    public getUtils() {
+        return {
+            NotionSdk: this.NotionSdk,
+        };
     }
 }

--- a/config/settings.ts
+++ b/config/settings.ts
@@ -1,0 +1,37 @@
+import {
+    ISetting,
+    SettingType,
+} from "@rocket.chat/apps-engine/definition/settings";
+
+// The settings that will be available for the App
+enum OAuth2Setting {
+    CLIENT_ID = "notion-client-id",
+    CLIENT_SECRET = "notion-client-secret",
+}
+
+export const settings: Array<ISetting> = [
+    {
+        id: OAuth2Setting.CLIENT_ID,
+        type: SettingType.STRING,
+        packageValue: "",
+        required: true,
+        public: false,
+        section: "CredentialSettings",
+        i18nLabel: "ClientIdLabel",
+        i18nPlaceholder: "ClientIdPlaceholder",
+        hidden: false,
+        multiline: false,
+    },
+    {
+        id: OAuth2Setting.CLIENT_SECRET,
+        type: SettingType.PASSWORD,
+        packageValue: "",
+        required: true,
+        public: false,
+        section: "CredentialSettings",
+        i18nLabel: "ClientSecretLabel",
+        i18nPlaceholder: "ClientSecretPlaceholder",
+        hidden: false,
+        multiline: false,
+    },
+];

--- a/config/settings.ts
+++ b/config/settings.ts
@@ -4,7 +4,8 @@ import {
 } from "@rocket.chat/apps-engine/definition/settings";
 
 // The settings that will be available for the App
-enum OAuth2Setting {
+// warning(AppsEngine Error): Having OAuth2Setting in enums folder causing an error in deployment reason not known.
+export enum OAuth2Setting {
     CLIENT_ID = "notion-client-id",
     CLIENT_SECRET = "notion-client-secret",
 }

--- a/definition/authorization/ICredential.ts
+++ b/definition/authorization/ICredential.ts
@@ -1,0 +1,5 @@
+export interface ICredential {
+    clientId: string;
+    clientSecret: string;
+    siteUrl: string;
+}

--- a/definition/authorization/IOAuth2Storage.ts
+++ b/definition/authorization/IOAuth2Storage.ts
@@ -1,0 +1,39 @@
+import { NotionOwnerType, NotionTokenType } from "../../enum/Notion";
+
+export interface IOAuth2Storage {
+    connectUserToWorkspace(
+        tokenInfo: ITokenInfo,
+        userId: string
+    ): Promise<void>;
+    getCurrentWorkspace(userId: string): Promise<ITokenInfo | null>;
+    disconnectUserFromCurrentWorkspace(userId: string): Promise<ITokenInfo | null>;
+}
+
+export interface ITokenInfo {
+    access_token: string;
+    token_type: NotionTokenType.TOKEN_TYPE;
+    bot_id: string;
+    workspace_icon: string | null;
+    workspace_id: string;
+    workspace_name: string | null;
+    owner: INotionOwner;
+    duplicated_template_id: string | null;
+}
+
+interface INotionOwner {
+    type: NotionOwnerType.USER;
+    user: INotionUser;
+}
+
+interface INotionUser {
+    object: NotionOwnerType.USER;
+    id: string;
+    name: string | null;
+    avatar_url: string | null;
+    type: NotionOwnerType.PERSON;
+    person: INotionPerson;
+}
+
+interface INotionPerson {
+    email: string;
+}

--- a/definition/authorization/IOAuthClient.ts
+++ b/definition/authorization/IOAuthClient.ts
@@ -26,5 +26,10 @@ export interface IOAuth2Client {
         persis: IPersistence
     ): Promise<void>;
 
-    getAuthorizationUrl(user: IUser, read: IRead): Promise<string>;
+    getAuthorizationUrl(
+        user: IUser,
+        read: IRead,
+        modify: IModify,
+        room: IRoom
+    ): Promise<string | null>;
 }

--- a/definition/authorization/IOAuthClient.ts
+++ b/definition/authorization/IOAuthClient.ts
@@ -5,6 +5,7 @@ import {
     IRead,
 } from "@rocket.chat/apps-engine/definition/accessors";
 import { SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
 
 export interface IOAuth2Client {
     connect(
@@ -22,4 +23,6 @@ export interface IOAuth2Client {
         http: IHttp,
         persis: IPersistence
     ): Promise<void>;
+
+    getAuthorizationUrl(user: IUser, read: IRead): Promise<string>;
 }

--- a/definition/authorization/IOAuthClient.ts
+++ b/definition/authorization/IOAuthClient.ts
@@ -1,0 +1,25 @@
+import {
+    IHttp,
+    IModify,
+    IPersistence,
+    IRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import { SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
+
+export interface IOAuth2Client {
+    connect(
+        context: SlashCommandContext,
+        read: IRead,
+        modify: IModify,
+        http: IHttp,
+        persis: IPersistence
+    ): Promise<void>;
+
+    disconnect(
+        context: SlashCommandContext,
+        read: IRead,
+        modify: IModify,
+        http: IHttp,
+        persis: IPersistence
+    ): Promise<void>;
+}

--- a/definition/authorization/IOAuthClient.ts
+++ b/definition/authorization/IOAuthClient.ts
@@ -4,12 +4,13 @@ import {
     IPersistence,
     IRead,
 } from "@rocket.chat/apps-engine/definition/accessors";
-import { SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
 
 export interface IOAuth2Client {
     connect(
-        context: SlashCommandContext,
+        room: IRoom,
+        sender: IUser,
         read: IRead,
         modify: IModify,
         http: IHttp,
@@ -17,7 +18,8 @@ export interface IOAuth2Client {
     ): Promise<void>;
 
     disconnect(
-        context: SlashCommandContext,
+        room: IRoom,
+        sender: IUser,
         read: IRead,
         modify: IModify,
         http: IHttp,

--- a/definition/command/ICommandUtility.ts
+++ b/definition/command/ICommandUtility.ts
@@ -1,0 +1,35 @@
+import {
+    IHttp,
+    IModify,
+    IPersistence,
+    IRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { NotionApp } from "../../NotionApp";
+import { SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
+
+export interface ICommandUtility {
+    app: NotionApp;
+    context: SlashCommandContext;
+    params: Array<string>;
+    sender: IUser;
+    room: IRoom;
+    read: IRead;
+    modify: IModify;
+    http: IHttp;
+    persis: IPersistence;
+    triggerId?: string;
+    threadId?: string;
+
+    resolveCommand(): Promise<void>;
+}
+
+export interface ICommandUtilityParams {
+    context: SlashCommandContext;
+    read: IRead;
+    modify: IModify;
+    http: IHttp;
+    persis: IPersistence;
+    app: NotionApp;
+}

--- a/definition/command/ICommandUtility.ts
+++ b/definition/command/ICommandUtility.ts
@@ -7,11 +7,9 @@ import {
 import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
 import { NotionApp } from "../../NotionApp";
-import { SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
 
 export interface ICommandUtility {
     app: NotionApp;
-    context: SlashCommandContext;
     params: Array<string>;
     sender: IUser;
     room: IRoom;
@@ -26,10 +24,14 @@ export interface ICommandUtility {
 }
 
 export interface ICommandUtilityParams {
-    context: SlashCommandContext;
+    app: NotionApp;
+    params: Array<string>;
+    sender: IUser;
+    room: IRoom;
     read: IRead;
     modify: IModify;
     http: IHttp;
     persis: IPersistence;
-    app: NotionApp;
+    triggerId?: string;
+    threadId?: string;
 }

--- a/definition/errors/IError.ts
+++ b/definition/errors/IError.ts
@@ -1,4 +1,4 @@
 export interface IError extends Error {
-    status: number;
+    statusCode: number;
     additionalInfo?: string;
 }

--- a/definition/errors/IError.ts
+++ b/definition/errors/IError.ts
@@ -1,0 +1,4 @@
+export interface IError extends Error {
+    status: number;
+    additionalInfo?: string;
+}

--- a/definition/lib/IAppUtils.ts
+++ b/definition/lib/IAppUtils.ts
@@ -1,0 +1,9 @@
+import { BlockBuilder } from "../../src/lib/BlockBuilder";
+import { ElementBuilder } from "../../src/lib/ElementBuilder";
+import { NotionSDK } from "../../src/lib/NotionSDK";
+
+export interface IAppUtils {
+    NotionSdk: NotionSDK;
+    elementBuilder: ElementBuilder;
+    blockBuilder: BlockBuilder;
+}

--- a/definition/lib/INotion.ts
+++ b/definition/lib/INotion.ts
@@ -1,0 +1,21 @@
+import { IHttp, IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { URL } from "url";
+import { ITokenInfo } from "../authorization/IOAuth2Storage";
+import { ClientError } from "../../errors/Error";
+import { NotionApi } from "../../enum/Notion";
+
+export interface INotion {
+    baseUrl: string;
+    NotionVersion: string;
+}
+
+export interface INotionSDK extends INotion {
+    getAuthorizationUrl(user: IUser, read: IRead): Promise<string>;
+    createToken(
+        http: IHttp,
+        redirectUrl: URL,
+        code: string,
+        credentials: string
+    ): Promise<ITokenInfo | ClientError>;
+}

--- a/definition/lib/INotion.ts
+++ b/definition/lib/INotion.ts
@@ -10,8 +10,8 @@ export interface INotion {
 }
 
 export interface INotionSDK extends INotion {
+    http: IHttp;
     createToken(
-        http: IHttp,
         redirectUrl: URL,
         code: string,
         credentials: string

--- a/definition/lib/INotion.ts
+++ b/definition/lib/INotion.ts
@@ -1,5 +1,4 @@
-import { IHttp, IRead } from "@rocket.chat/apps-engine/definition/accessors";
-import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { IHttp } from "@rocket.chat/apps-engine/definition/accessors";
 import { URL } from "url";
 import { ITokenInfo } from "../authorization/IOAuth2Storage";
 import { ClientError } from "../../errors/Error";
@@ -11,7 +10,6 @@ export interface INotion {
 }
 
 export interface INotionSDK extends INotion {
-    getAuthorizationUrl(user: IUser, read: IRead): Promise<string>;
     createToken(
         http: IHttp,
         redirectUrl: URL,

--- a/definition/lib/IRoomInteraction.ts
+++ b/definition/lib/IRoomInteraction.ts
@@ -1,0 +1,5 @@
+export interface IRoomInteractionStorage {
+    storeInteractionRoomId(userId: string, roomId: string): Promise<void>;
+    getInteractionRoomId(userId: string): Promise<string>;
+    clearInteractionRoomId(userId: string): Promise<void>;
+}

--- a/definition/ui-kit/Block/IActionBlock.ts
+++ b/definition/ui-kit/Block/IActionBlock.ts
@@ -1,0 +1,3 @@
+import { ActionsBlock } from "@rocket.chat/ui-kit";
+
+export type ActionBlockParam = Pick<ActionsBlock, "blockId" | "elements">;

--- a/definition/ui-kit/Block/IBlockBuilder.ts
+++ b/definition/ui-kit/Block/IBlockBuilder.ts
@@ -1,0 +1,8 @@
+import { SectionBlock, ActionsBlock } from "@rocket.chat/ui-kit";
+import { SectionBlockParam } from "./ISectionBlock";
+import { ActionBlockParam } from "./IActionBlock";
+
+export interface IBlockBuilder {
+    createSectionBlock(param: SectionBlockParam): SectionBlock;
+    createActionBlock(param: ActionBlockParam): ActionsBlock;
+}

--- a/definition/ui-kit/Block/IBlockBuilder.ts
+++ b/definition/ui-kit/Block/IBlockBuilder.ts
@@ -1,8 +1,20 @@
-import { SectionBlock, ActionsBlock } from "@rocket.chat/ui-kit";
+import {
+    SectionBlock,
+    ActionsBlock,
+    PreviewBlockBase,
+    PreviewBlockWithThumb,
+    ContextBlock,
+} from "@rocket.chat/ui-kit";
 import { SectionBlockParam } from "./ISectionBlock";
 import { ActionBlockParam } from "./IActionBlock";
+import { PreviewBlockParam } from "./IPreviewBlock";
+import { ContextBlockParam } from "./IContextBlock";
 
 export interface IBlockBuilder {
     createSectionBlock(param: SectionBlockParam): SectionBlock;
     createActionBlock(param: ActionBlockParam): ActionsBlock;
+    createPreviewBlock(
+        param: PreviewBlockParam
+    ): PreviewBlockBase | PreviewBlockWithThumb;
+    createContextBlock(param: ContextBlockParam): ContextBlock;
 }

--- a/definition/ui-kit/Block/IContextBlock.ts
+++ b/definition/ui-kit/Block/IContextBlock.ts
@@ -1,0 +1,7 @@
+import { ImageParam } from "../Element/IImageElement";
+import { ImageElement } from "@rocket.chat/ui-kit";
+
+export type ContextBlockParam = {
+    contextElements: Array<string | ImageElement>;
+    blockId?: string;
+};

--- a/definition/ui-kit/Block/IPreviewBlock.ts
+++ b/definition/ui-kit/Block/IPreviewBlock.ts
@@ -1,0 +1,8 @@
+import { PreviewBlockWithThumb } from "@rocket.chat/ui-kit";
+
+export type PreviewBlockParam = Partial<
+    Pick<PreviewBlockWithThumb, "footer" | "thumb">
+> & {
+    title: Array<string>;
+    description: Array<string>;
+};

--- a/definition/ui-kit/Block/ISectionBlock.ts
+++ b/definition/ui-kit/Block/ISectionBlock.ts
@@ -1,0 +1,6 @@
+import { SectionBlock } from "@rocket.chat/ui-kit";
+
+export type SectionBlockParam = Pick<SectionBlock, "accessory" | "blockId"> & {
+    text?: string;
+    fields?: Array<string>;
+};

--- a/definition/ui-kit/Element/IButtonElement.ts
+++ b/definition/ui-kit/Element/IButtonElement.ts
@@ -1,0 +1,5 @@
+import { ButtonElement } from "@rocket.chat/ui-kit";
+
+export type ButtonParam = Pick<ButtonElement, "value" | "style" | "url"> & {
+    text: string;
+};

--- a/definition/ui-kit/Element/IElementBuilder.ts
+++ b/definition/ui-kit/Element/IElementBuilder.ts
@@ -1,12 +1,14 @@
 import { ButtonStyle } from "@rocket.chat/apps-engine/definition/uikit";
-import { ButtonElement } from "@rocket.chat/ui-kit";
+import { ButtonElement, ImageElement } from "@rocket.chat/ui-kit";
 import { ButtonParam } from "./IButtonElement";
+import { ImageParam } from "./IImageElement";
 
 export interface IElementBuilder {
     addButton(
         param: ButtonParam,
         interaction: ElementInteractionParam
     ): ButtonElement;
+    addImage(param: ImageParam): ImageElement;
 }
 
 export type ElementInteractionParam = { blockId: string; actionId: string };

--- a/definition/ui-kit/Element/IElementBuilder.ts
+++ b/definition/ui-kit/Element/IElementBuilder.ts
@@ -1,0 +1,12 @@
+import { ButtonStyle } from "@rocket.chat/apps-engine/definition/uikit";
+import { ButtonElement } from "@rocket.chat/ui-kit";
+import { ButtonParam } from "./IButtonElement";
+
+export interface IElementBuilder {
+    addButton(
+        param: ButtonParam,
+        interaction: ElementInteractionParam
+    ): ButtonElement;
+}
+
+export type ElementInteractionParam = { blockId: string; actionId: string };

--- a/definition/ui-kit/Element/IImageElement.ts
+++ b/definition/ui-kit/Element/IImageElement.ts
@@ -1,0 +1,3 @@
+import { ImageElement } from "@rocket.chat/ui-kit";
+
+export type ImageParam = Pick<ImageElement, "imageUrl" | "altText">;

--- a/enum/CommandParam.ts
+++ b/enum/CommandParam.ts
@@ -1,0 +1,4 @@
+export enum CommandParam {
+    CONNECT = "connect",
+    DISCONNECT = "disconnect",
+}

--- a/enum/Error.ts
+++ b/enum/Error.ts
@@ -1,0 +1,8 @@
+export enum ErrorName {
+    BAD_REQUEST = "Bad Request",
+    UNAUTHORIZED = "Unauthorized",
+    SERVER_ERROR = "Internal Server Error",
+    FORBIDDEN = "Forbidden",
+    MANY_REQUESTS = "Too Many Requests",
+    NOT_FOUND = "Not Found",
+}

--- a/enum/Notion.ts
+++ b/enum/Notion.ts
@@ -1,0 +1,17 @@
+export enum NotionTokenType {
+    TOKEN_TYPE = "bearer",
+    CURRENT_WORKSPACE = "notion_current_workspace",
+}
+
+export enum NotionOwnerType {
+    USER = "user",
+    PERSON = "person",
+    BOT = "bot",
+}
+
+export enum NotionApi {
+    BASE_URL = "https://api.notion.com/v1",
+    VERSION = "2022-06-28",
+    USER_AGENT = "Rocket.Chat-Apps-Engine",
+    CONTENT_TYPE = "application/json",
+}

--- a/enum/Notion.ts
+++ b/enum/Notion.ts
@@ -15,3 +15,7 @@ export enum NotionApi {
     USER_AGENT = "Rocket.Chat-Apps-Engine",
     CONTENT_TYPE = "application/json",
 }
+
+export enum Notion {
+    WEBSITE_URL = "https://www.notion.so",
+}

--- a/enum/OAuth2.ts
+++ b/enum/OAuth2.ts
@@ -6,17 +6,8 @@ export enum OAuth2Locator {
 }
 
 export enum OAuth2Content {
-    success = '<div style="display: flex;align-items: center;justify-content: center; height: 100%;">\
-                        <h1 style="text-align: center; font-family: Helvetica Neue;">\
-                            Authorization went successfully<br>\
-                            You can close this tab now<br>\
-                        </h1>\
-              </div>',
-    failed = '<div style="display: flex;align-items: center;justify-content: center; height: 100%;">\
-                    <h1 style="text-align: center; font-family: Helvetica Neue;">\
-                        Oops, something went wrong, please try again or in case it still does not work, contact the administrator.\
-                    </h1>\
-             </div>',
+    success = "https://github-production-user-asset-6210df.s3.amazonaws.com/65061890/243671111-9964efff-3b23-4223-aadd-5f4be441037c.svg",
+    failed = "https://open.rocket.chat/assets/logo.png",
 }
 
 export enum OAuth2Credential {

--- a/enum/OAuth2.ts
+++ b/enum/OAuth2.ts
@@ -27,3 +27,11 @@ export enum OAuth2Credential {
     REDIRECT_URI = "redirect_uri",
     STATE = "state",
 }
+
+export enum OAuth2Block {
+    CONNECT_TO_WORKSPACE = "connect-to-workspace-block",
+}
+
+export enum OAuth2Action {
+    CONNECT_TO_WORKSPACE = "connect-to-workspace-action",
+}

--- a/enum/OAuth2.ts
+++ b/enum/OAuth2.ts
@@ -1,0 +1,29 @@
+export enum OAuth2Locator {
+    authUri = "https://api.notion.com/v1/oauth/authorize?owner=user&response_type=code&",
+    accessTokenUrl = "https://api.notion.com/v1/oauth/token",
+    refreshTokenUrl = "https://api.notion.com/v1/oauth/token",
+    redirectUrlPath = "/api/apps/public/fb6e4e74-f99d-41b6-96da-2486e9aafea8/webhook",
+}
+
+export enum OAuth2Content {
+    success = '<div style="display: flex;align-items: center;justify-content: center; height: 100%;">\
+                        <h1 style="text-align: center; font-family: Helvetica Neue;">\
+                            Authorization went successfully<br>\
+                            You can close this tab now<br>\
+                        </h1>\
+              </div>',
+    failed = '<div style="display: flex;align-items: center;justify-content: center; height: 100%;">\
+                    <h1 style="text-align: center; font-family: Helvetica Neue;">\
+                        Oops, something went wrong, please try again or in case it still does not work, contact the administrator.\
+                    </h1>\
+             </div>',
+}
+
+export enum OAuth2Credential {
+    TYPE = "Basic",
+    GRANT_TYPE = "authorization_code",
+    FORMAT = "base64",
+    CLIENT_ID = "client_id",
+    REDIRECT_URI = "redirect_uri",
+    STATE = "state",
+}

--- a/enum/Settings.ts
+++ b/enum/Settings.ts
@@ -1,3 +1,4 @@
 export enum ServerSetting {
     SITE_URL = "Site_Url",
+    USER_ROLE_ADMIN = "admin",
 }

--- a/enum/Settings.ts
+++ b/enum/Settings.ts
@@ -1,0 +1,3 @@
+export enum ServerSetting {
+    SITE_URL = "Site_Url",
+}

--- a/errors/Error.ts
+++ b/errors/Error.ts
@@ -12,18 +12,18 @@ import { ErrorName } from "../enum/Error";
 class Error implements IError {
     name: string;
     message: string;
-    status: number;
+    statusCode: number;
     additionalInfo?: string;
 
     constructor(
         name: string,
         message: string,
-        status: number,
+        statusCode: number,
         additionalInfo?: string
     ) {
         this.name = name;
         this.message = message;
-        this.status = status;
+        this.statusCode = statusCode;
         this.additionalInfo = additionalInfo;
     }
 }

--- a/errors/Error.ts
+++ b/errors/Error.ts
@@ -1,0 +1,95 @@
+/* 
+    - This file contains all the errors that can be handle by the application includes: 400, 401, 403, 404, 429, 500
+    - The error name is the type of the error
+    - The message is the message that will be logged in the console
+    - The status is the status code of the error
+    - The additionalInfo is the additional information that will be logged in the console
+*/
+import { IError } from "../definition/errors/IError";
+import { HttpStatusCode } from "@rocket.chat/apps-engine/definition/accessors";
+import { ErrorName } from "../enum/Error";
+
+class Error implements IError {
+    name: string;
+    message: string;
+    status: number;
+    additionalInfo?: string;
+
+    constructor(
+        name: string,
+        message: string,
+        status: number,
+        additionalInfo?: string
+    ) {
+        this.name = name;
+        this.message = message;
+        this.status = status;
+        this.additionalInfo = additionalInfo;
+    }
+}
+
+export class ClientError extends Error {
+    constructor(message: string, additionalInfo?: string) {
+        super(
+            ErrorName.BAD_REQUEST,
+            message,
+            HttpStatusCode.BAD_REQUEST,
+            additionalInfo
+        );
+    }
+}
+
+export class NotFoundError extends Error {
+    constructor(message: string, additionalInfo?: string) {
+        super(
+            ErrorName.NOT_FOUND,
+            message,
+            HttpStatusCode.NOT_FOUND,
+            additionalInfo
+        );
+    }
+}
+
+export class UnAuthorizedError extends Error {
+    constructor(message: string, additionalInfo?: string) {
+        super(
+            ErrorName.UNAUTHORIZED,
+            message,
+            HttpStatusCode.UNAUTHORIZED,
+            additionalInfo
+        );
+    }
+}
+
+export class ForbiddenError extends Error {
+    constructor(message: string, additionalInfo?: string) {
+        super(
+            ErrorName.FORBIDDEN,
+            message,
+            HttpStatusCode.FORBIDDEN,
+            additionalInfo
+        );
+    }
+}
+
+export class ServerError extends Error {
+    constructor(message: string, additionalInfo?: string) {
+        super(
+            ErrorName.SERVER_ERROR,
+            message,
+            HttpStatusCode.INTERNAL_SERVER_ERROR,
+            additionalInfo
+        );
+    }
+}
+
+export class ManyRequestsError extends Error {
+    constructor(message: string, additionalInfo?: string) {
+        super(
+            ErrorName.MANY_REQUESTS,
+            message,
+            HttpStatusCode.TOO_MANY_REQUESTS,
+            additionalInfo
+        );
+    }
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,7 @@
+{
+    "ClientIdLabel": "notion-client-id",
+    "ClientIdPlaceholder": "paste your clientId here",
+    "ClientSecretLabel": "notion-client-secret",
+    "ClientSecretPlaceholder": "Shhh! This is super secret",
+    "CredentialsSettings": "Authorization Settings"
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,5 +3,7 @@
     "ClientIdPlaceholder": "paste your clientId here",
     "ClientSecretLabel": "notion-client-secret",
     "ClientSecretPlaceholder": "Shhh! This is super secret",
-    "CredentialsSettings": "Authorization Settings"
+    "CredentialsSettings": "Authorization Settings",
+    "NotionCommandParams": "connect | disconnect | workspace | create | schema | comment",
+    "NotionCommandDescription": "Create Notion pages and database from Rocket.Chat"
 }

--- a/src/authorization/OAuth2Client.ts
+++ b/src/authorization/OAuth2Client.ts
@@ -25,6 +25,4 @@ export class OAuth2Client implements IOAuth2Client {
         http: IHttp,
         persis: IPersistence
     ) {}
-
-    private async getCredentials(read: IRead) {}
 }

--- a/src/authorization/OAuth2Client.ts
+++ b/src/authorization/OAuth2Client.ts
@@ -26,7 +26,17 @@ export class OAuth2Client implements IOAuth2Client {
         persis: IPersistence
     ) {
         const { blockBuilder, elementBuilder } = this.app.getUtils();
-        const authorizationUrl = await this.getAuthorizationUrl(sender, read);
+        const authorizationUrl = await this.getAuthorizationUrl(
+            sender,
+            read,
+            modify,
+            room
+        );
+
+        if (!authorizationUrl) {
+            return;
+        }
+
         const message = `Hey **${sender.username}**!👋 Connect your Notion Workspace`;
         const blocks = await getConnectBlock(
             this.app,
@@ -61,7 +71,17 @@ export class OAuth2Client implements IOAuth2Client {
             return;
         }
 
-        const authorizationUrl = await this.getAuthorizationUrl(sender, read);
+        const authorizationUrl = await this.getAuthorizationUrl(
+            sender,
+            read,
+            modify,
+            room
+        );
+
+        if (!authorizationUrl) {
+            return;
+        }
+
         const message = `👋 You are not Connected to **Workspace**!`;
         const blocks = await getConnectBlock(
             this.app,
@@ -75,10 +95,18 @@ export class OAuth2Client implements IOAuth2Client {
 
     public async getAuthorizationUrl(
         user: IUser,
-        read: IRead
-    ): Promise<string> {
+        read: IRead,
+        modify: IModify,
+        room: IRoom
+    ): Promise<string | null> {
         const userId = user.id;
-        const { clientId, siteUrl } = await getCredentials(read);
+        const credentials = await getCredentials(read, modify, user, room);
+
+        if (!credentials) {
+            return null;
+        }
+
+        const { clientId, siteUrl } = credentials;
 
         const redirectUrl = new URL(OAuth2Locator.redirectUrlPath, siteUrl);
         const authorizationUrl = new URL(OAuth2Locator.authUri);

--- a/src/authorization/OAuth2Client.ts
+++ b/src/authorization/OAuth2Client.ts
@@ -8,6 +8,7 @@ import {
 } from "@rocket.chat/apps-engine/definition/accessors";
 import { IOAuth2Client } from "../../definition/authorization/IOAuthClient";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { OAuth2Storage } from "./OAuth2Storage";
 import { sendNotification } from "../helper/message";
 import { getCredentials } from "../helper/getCredential";
 import { OAuth2Credential, OAuth2Locator } from "../../enum/OAuth2";
@@ -45,7 +46,34 @@ export class OAuth2Client implements IOAuth2Client {
         modify: IModify,
         http: IHttp,
         persis: IPersistence
-    ) {}
+    ) {
+        const persistenceRead = read.getPersistenceReader();
+        const oAuthStorage = new OAuth2Storage(persis, persistenceRead);
+        const { blockBuilder, elementBuilder } = this.app.getUtils();
+
+        const room = context.getRoom();
+        const user = context.getSender();
+        const userId = user.id;
+        const tokenInfo = await oAuthStorage.getCurrentWorkspace(userId);
+
+        if (tokenInfo) {
+            await oAuthStorage.disconnectUserFromCurrentWorkspace(userId);
+            const message = `you are being disconnected from the Workspace **${tokenInfo.workspace_name}**`;
+            await sendNotification(read, modify, user, room, { message });
+            return;
+        }
+
+        const authorizationUrl = await this.getAuthorizationUrl(user, read);
+        const message = `you are not connected to workspace!`;
+        const blocks = await getConnectBlock(
+            this.app,
+            message,
+            authorizationUrl
+        );
+        await sendNotification(read, modify, user, room, {
+            blocks,
+        });
+    }
 
     public async getAuthorizationUrl(
         user: IUser,

--- a/src/authorization/OAuth2Client.ts
+++ b/src/authorization/OAuth2Client.ts
@@ -28,7 +28,7 @@ export class OAuth2Client implements IOAuth2Client {
         const user = context.getSender();
         const room = context.getRoom();
         const authorizationUrl = await this.getAuthorizationUrl(user, read);
-        const message = `Hey👋 ${user.username}!`;
+        const message = `Hey **${user.username}**!👋 Connect your Notion Workspace`;
         const blocks = await getConnectBlock(
             this.app,
             message,
@@ -58,13 +58,13 @@ export class OAuth2Client implements IOAuth2Client {
 
         if (tokenInfo) {
             await oAuthStorage.disconnectUserFromCurrentWorkspace(userId);
-            const message = `you are being disconnected from the Workspace **${tokenInfo.workspace_name}**`;
+            const message = `👋 You are disconnected from the Workspace **${tokenInfo.workspace_name}**`;
             await sendNotification(read, modify, user, room, { message });
             return;
         }
 
         const authorizationUrl = await this.getAuthorizationUrl(user, read);
-        const message = `you are not connected to workspace!`;
+        const message = `👋 You are not Connected to **Workspace**!`;
         const blocks = await getConnectBlock(
             this.app,
             message,

--- a/src/authorization/OAuth2Client.ts
+++ b/src/authorization/OAuth2Client.ts
@@ -1,0 +1,30 @@
+import { SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
+import { NotionApp } from "../../NotionApp";
+import {
+    IHttp,
+    IModify,
+    IPersistence,
+    IRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import { IOAuth2Client } from "../../definition/authorization/IOAuthClient";
+
+export class OAuth2Client implements IOAuth2Client {
+    constructor(private readonly app: NotionApp) {}
+    public async connect(
+        context: SlashCommandContext,
+        read: IRead,
+        modify: IModify,
+        http: IHttp,
+        persis: IPersistence
+    ) {}
+
+    public async disconnect(
+        context: SlashCommandContext,
+        read: IRead,
+        modify: IModify,
+        http: IHttp,
+        persis: IPersistence
+    ) {}
+
+    private async getCredentials(read: IRead) {}
+}

--- a/src/authorization/OAuth2Client.ts
+++ b/src/authorization/OAuth2Client.ts
@@ -7,6 +7,10 @@ import {
     IRead,
 } from "@rocket.chat/apps-engine/definition/accessors";
 import { IOAuth2Client } from "../../definition/authorization/IOAuthClient";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { getCredentials } from "../helper/getCredential";
+import { OAuth2Credential, OAuth2Locator } from "../../enum/OAuth2";
+import { URL } from "url";
 
 export class OAuth2Client implements IOAuth2Client {
     constructor(private readonly app: NotionApp) {}
@@ -25,4 +29,23 @@ export class OAuth2Client implements IOAuth2Client {
         http: IHttp,
         persis: IPersistence
     ) {}
+
+    public async getAuthorizationUrl(
+        user: IUser,
+        read: IRead
+    ): Promise<string> {
+        const userId = user.id;
+        const { clientId, siteUrl } = await getCredentials(read);
+
+        const redirectUrl = new URL(OAuth2Locator.redirectUrlPath, siteUrl);
+        const authorizationUrl = new URL(OAuth2Locator.authUri);
+        authorizationUrl.searchParams.set(OAuth2Credential.CLIENT_ID, clientId);
+        authorizationUrl.searchParams.set(
+            OAuth2Credential.REDIRECT_URI,
+            redirectUrl.toString()
+        );
+        authorizationUrl.searchParams.set(OAuth2Credential.STATE, userId);
+
+        return authorizationUrl.toString();
+    }
 }

--- a/src/authorization/OAuth2Client.ts
+++ b/src/authorization/OAuth2Client.ts
@@ -8,9 +8,11 @@ import {
 } from "@rocket.chat/apps-engine/definition/accessors";
 import { IOAuth2Client } from "../../definition/authorization/IOAuthClient";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { sendNotification } from "../helper/message";
 import { getCredentials } from "../helper/getCredential";
 import { OAuth2Credential, OAuth2Locator } from "../../enum/OAuth2";
 import { URL } from "url";
+import { getConnectBlock } from "../helper/getConnectBlock";
 
 export class OAuth2Client implements IOAuth2Client {
     constructor(private readonly app: NotionApp) {}
@@ -20,7 +22,22 @@ export class OAuth2Client implements IOAuth2Client {
         modify: IModify,
         http: IHttp,
         persis: IPersistence
-    ) {}
+    ) {
+        const { blockBuilder, elementBuilder } = this.app.getUtils();
+        const user = context.getSender();
+        const room = context.getRoom();
+        const authorizationUrl = await this.getAuthorizationUrl(user, read);
+        const message = `Hey👋 ${user.username}!`;
+        const blocks = await getConnectBlock(
+            this.app,
+            message,
+            authorizationUrl
+        );
+
+        await sendNotification(read, modify, user, room, {
+            blocks,
+        });
+    }
 
     public async disconnect(
         context: SlashCommandContext,

--- a/src/authorization/OAuth2Storage.ts
+++ b/src/authorization/OAuth2Storage.ts
@@ -1,0 +1,76 @@
+import {
+    IPersistence,
+    IPersistenceRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import {
+    IOAuth2Storage,
+    ITokenInfo,
+} from "../../definition/authorization/IOAuth2Storage";
+import {
+    RocketChatAssociationModel,
+    RocketChatAssociationRecord,
+} from "@rocket.chat/apps-engine/definition/metadata";
+import { NotionTokenType } from "../../enum/Notion";
+
+export class OAuth2Storage implements IOAuth2Storage {
+    constructor(
+        private readonly persistence: IPersistence,
+        private readonly persistenceRead: IPersistenceRead
+    ) {}
+    public async connectUserToWorkspace(
+        tokenInfo: ITokenInfo,
+        userId: string
+    ): Promise<void> {
+        await this.persistence.updateByAssociations(
+            [
+                new RocketChatAssociationRecord( // user association
+                    RocketChatAssociationModel.USER,
+                    userId
+                ),
+                new RocketChatAssociationRecord(
+                    RocketChatAssociationModel.MISC,
+                    NotionTokenType.CURRENT_WORKSPACE
+                ),
+            ],
+            tokenInfo,
+            true
+        );
+
+        return;
+    }
+
+    public async getCurrentWorkspace(
+        userId: string
+    ): Promise<ITokenInfo | null> {
+        const [tokenInfo] = (await this.persistenceRead.readByAssociations([
+            new RocketChatAssociationRecord( // user association
+                RocketChatAssociationModel.USER,
+                userId
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                NotionTokenType.CURRENT_WORKSPACE
+            ),
+        ])) as ITokenInfo[];
+
+        return tokenInfo;
+    }
+
+    public async disconnectUserFromCurrentWorkspace(
+        userId: string
+    ): Promise<ITokenInfo | null> {
+        const [removedTokenInfo] = (await this.persistence.removeByAssociations(
+            [
+                new RocketChatAssociationRecord( // user association
+                    RocketChatAssociationModel.USER,
+                    userId
+                ),
+                new RocketChatAssociationRecord(
+                    RocketChatAssociationModel.MISC,
+                    NotionTokenType.CURRENT_WORKSPACE
+                ),
+            ]
+        )) as ITokenInfo[];
+        return removedTokenInfo;
+    }
+}

--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -12,11 +12,9 @@ import {
     ICommandUtilityParams,
 } from "../../definition/command/ICommandUtility";
 import { CommandParam } from "../../enum/CommandParam";
-import { SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
 
 export class CommandUtility implements ICommandUtility {
     public app: NotionApp;
-    public context: SlashCommandContext;
     public params: Array<string>;
     public sender: IUser;
     public room: IRoom;
@@ -29,16 +27,15 @@ export class CommandUtility implements ICommandUtility {
 
     constructor(props: ICommandUtilityParams) {
         this.app = props.app;
-        this.context = props.context;
+        this.params = props.params;
+        this.sender = props.sender;
+        this.room = props.room;
         this.read = props.read;
         this.modify = props.modify;
         this.http = props.http;
         this.persis = props.persis;
-        this.params = props.context.getArguments();
-        this.sender = props.context.getSender();
-        this.room = props.context.getRoom();
-        this.triggerId = props.context.getTriggerId();
-        this.threadId = props.context.getThreadId();
+        this.triggerId = props.triggerId;
+        this.threadId = props.threadId;
     }
 
     public async resolveCommand(): Promise<void> {
@@ -60,7 +57,8 @@ export class CommandUtility implements ICommandUtility {
         switch (this.params[0]) {
             case CommandParam.CONNECT: {
                 await oAuth2ClientInstance.connect(
-                    this.context,
+                    this.room,
+                    this.sender,
                     this.read,
                     this.modify,
                     this.http,
@@ -70,7 +68,8 @@ export class CommandUtility implements ICommandUtility {
             }
             case CommandParam.DISCONNECT: {
                 await oAuth2ClientInstance.disconnect(
-                    this.context,
+                    this.room,
+                    this.sender,
                     this.read,
                     this.modify,
                     this.http,

--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -54,7 +54,7 @@ export class CommandUtility implements ICommandUtility {
 
     private async handleSingleParam(): Promise<void> {
         const oAuth2ClientInstance = await this.app.getOAuth2Client();
-        switch (this.params[0]) {
+        switch (this.params[0].toLowerCase()) {
             case CommandParam.CONNECT: {
                 await oAuth2ClientInstance.connect(
                     this.room,

--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -1,0 +1,85 @@
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { NotionApp } from "../../NotionApp";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import {
+    IHttp,
+    IModify,
+    IPersistence,
+    IRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import {
+    ICommandUtility,
+    ICommandUtilityParams,
+} from "../../definition/command/ICommandUtility";
+import { CommandParam } from "../../enum/CommandParam";
+import { SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
+
+export class CommandUtility implements ICommandUtility {
+    public app: NotionApp;
+    public context: SlashCommandContext;
+    public params: Array<string>;
+    public sender: IUser;
+    public room: IRoom;
+    public read: IRead;
+    public modify: IModify;
+    public http: IHttp;
+    public persis: IPersistence;
+    public triggerId?: string;
+    public threadId?: string;
+
+    constructor(props: ICommandUtilityParams) {
+        this.app = props.app;
+        this.context = props.context;
+        this.read = props.read;
+        this.modify = props.modify;
+        this.http = props.http;
+        this.persis = props.persis;
+        this.params = props.context.getArguments();
+        this.sender = props.context.getSender();
+        this.room = props.context.getRoom();
+        this.triggerId = props.context.getTriggerId();
+        this.threadId = props.context.getThreadId();
+    }
+
+    public async resolveCommand(): Promise<void> {
+        switch (this.params.length) {
+            case 0: {
+                break;
+            }
+            case 1: {
+                await this.handleSingleParam();
+                break;
+            }
+            default: {
+            }
+        }
+    }
+
+    private async handleSingleParam(): Promise<void> {
+        const oAuth2ClientInstance = await this.app.getOAuth2Client();
+        switch (this.params[0]) {
+            case CommandParam.CONNECT: {
+                await oAuth2ClientInstance.connect(
+                    this.context,
+                    this.read,
+                    this.modify,
+                    this.http,
+                    this.persis
+                );
+                break;
+            }
+            case CommandParam.DISCONNECT: {
+                await oAuth2ClientInstance.disconnect(
+                    this.context,
+                    this.read,
+                    this.modify,
+                    this.http,
+                    this.persis
+                );
+                break;
+            }
+            default: {
+            }
+        }
+    }
+}

--- a/src/commands/NotionCommand.ts
+++ b/src/commands/NotionCommand.ts
@@ -27,8 +27,18 @@ export class NotionCommand implements ISlashCommand {
         http: IHttp,
         persis: IPersistence
     ): Promise<void> {
+        const params = context.getArguments();
+        const sender = context.getSender();
+        const room = context.getRoom();
+        const triggerId = context.getTriggerId();
+        const threadId = context.getThreadId();
+
         const commandUtilityParams: ICommandUtilityParams = {
-            context,
+            params,
+            sender,
+            room,
+            triggerId,
+            threadId,
             read,
             modify,
             http,

--- a/src/commands/NotionCommand.ts
+++ b/src/commands/NotionCommand.ts
@@ -1,0 +1,42 @@
+import {
+    ISlashCommand,
+    SlashCommandContext,
+} from "@rocket.chat/apps-engine/definition/slashcommands";
+import { NotionApp } from "../../NotionApp";
+import {
+    IHttp,
+    IModify,
+    IPersistence,
+    IRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import { ICommandUtilityParams } from "../../definition/command/ICommandUtility";
+import { CommandUtility } from "./CommandUtility";
+
+export class NotionCommand implements ISlashCommand {
+    constructor(private readonly app: NotionApp) {}
+
+    public command: string = "notion";
+    public i18nParamsExample: string = "NotionCommandParams";
+    public i18nDescription: string = "NotionCommandDescription";
+    public providesPreview: boolean = false;
+
+    public async executor(
+        context: SlashCommandContext,
+        read: IRead,
+        modify: IModify,
+        http: IHttp,
+        persis: IPersistence
+    ): Promise<void> {
+        const commandUtilityParams: ICommandUtilityParams = {
+            context,
+            read,
+            modify,
+            http,
+            persis,
+            app: this.app,
+        };
+
+        const commandUtility = new CommandUtility(commandUtilityParams);
+        await commandUtility.resolveCommand();
+    }
+}

--- a/src/endpoints/webhook.ts
+++ b/src/endpoints/webhook.ts
@@ -25,6 +25,7 @@ import { sendNotification } from "../helper/message";
 import { BlockBuilder } from "../lib/BlockBuilder";
 import { NotionSDK } from "../lib/NotionSDK";
 import { RoomInteractionStorage } from "../storage/RoomInteraction";
+import { getConnectPreview } from "../helper/getConnectLayout";
 
 export class WebHookEndpoint extends ApiEndpoint {
     public path: string = "webhook";
@@ -95,15 +96,9 @@ export class WebHookEndpoint extends ApiEndpoint {
         const roomId = await roomInteraction.getInteractionRoomId(user.id);
         const room = (await read.getRoomReader().getById(roomId)) as IRoom;
 
-        const workspaceName = response.workspace_name as string;
-
-        const blockBuilder = new BlockBuilder(this.app.getID());
-        const sectionBlock = blockBuilder.createSectionBlock({
-            text: `👋You are connected to Workspace **${workspaceName}**`,
-        });
-
+        const connectPreview = getConnectPreview(this.app.getID(), response);
         await sendNotification(read, modify, user, room, {
-            blocks: [sectionBlock],
+            blocks: [connectPreview],
         });
         await roomInteraction.clearInteractionRoomId(user.id);
 

--- a/src/endpoints/webhook.ts
+++ b/src/endpoints/webhook.ts
@@ -93,9 +93,8 @@ export class WebHookEndpoint extends ApiEndpoint {
             OAuth2Credential.FORMAT
         );
 
-        const notionSDK = new NotionSDK();
+        const notionSDK = new NotionSDK(http);
         const response = await notionSDK.createToken(
-            http,
             redirectUrl,
             code,
             credentials

--- a/src/endpoints/webhook.ts
+++ b/src/endpoints/webhook.ts
@@ -1,0 +1,112 @@
+import {
+    HttpStatusCode,
+    IHttp,
+    IModify,
+    IPersistence,
+    IRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import {
+    ApiEndpoint,
+    IApiEndpointInfo,
+    IApiRequest,
+    IApiResponse,
+} from "@rocket.chat/apps-engine/definition/api";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import { URL } from "url";
+import {
+    OAuth2Content,
+    OAuth2Credential,
+    OAuth2Locator,
+} from "../../enum/OAuth2";
+import { ClientError } from "../../errors/Error";
+import { OAuth2Storage } from "../authorization/OAuth2Storage";
+import { getCredentials } from "../helper/getCredential";
+import { sendNotification } from "../helper/message";
+import { BlockBuilder } from "../lib/BlockBuilder";
+import { NotionSDK } from "../lib/NotionSDK";
+import { RoomInteractionStorage } from "../storage/RoomInteraction";
+
+export class WebHookEndpoint extends ApiEndpoint {
+    public path: string = "webhook";
+    public url_path: string = OAuth2Locator.redirectUrlPath;
+    public accessTokenUrl: string = OAuth2Locator.accessTokenUrl;
+    public async get(
+        request: IApiRequest,
+        endpoint: IApiEndpointInfo,
+        read: IRead,
+        modify: IModify,
+        http: IHttp,
+        persis: IPersistence
+    ): Promise<IApiResponse> {
+        const { code, state, error } = request.query;
+
+        // incase when user leaves in between the auth process
+        if (error) {
+            this.app.getLogger().warn(error);
+            return {
+                status: HttpStatusCode.UNAUTHORIZED,
+                content: OAuth2Content.failed,
+            };
+        }
+
+        const user = await read.getUserReader().getById(state);
+        // incase when user changed the state in authUrl
+        if (!user) {
+            this.app
+                .getLogger()
+                .warn(`User not found before access token request`);
+            return {
+                status: HttpStatusCode.NON_AUTHORITATIVE_INFORMATION,
+                content: OAuth2Content.failed,
+            };
+        }
+
+        const { clientId, clientSecret, siteUrl } = await getCredentials(read);
+        const redirectUrl = new URL(this.url_path, siteUrl);
+        const credentials = new Buffer(`${clientId}:${clientSecret}`).toString(
+            OAuth2Credential.FORMAT
+        );
+
+        const notionSDK = new NotionSDK();
+        const response = await notionSDK.createToken(
+            http,
+            redirectUrl,
+            code,
+            credentials
+        );
+
+        // incase there is some error in creation of Token from Notion
+        if (response instanceof ClientError) {
+            this.app.getLogger().warn(response.message);
+            return {
+                status: response.statusCode,
+                content: OAuth2Content.failed,
+            };
+        }
+
+        const persistenceRead = read.getPersistenceReader();
+        const oAuth2Storage = new OAuth2Storage(persis, persistenceRead);
+        await oAuth2Storage.connectUserToWorkspace(response, state);
+
+        const roomInteraction = new RoomInteractionStorage(
+            persis,
+            persistenceRead
+        );
+        const roomId = await roomInteraction.getInteractionRoomId(user.id);
+        const room = (await read.getRoomReader().getById(roomId)) as IRoom;
+
+        const workspaceName = response.workspace_name as string;
+
+        const blockBuilder = new BlockBuilder(this.app.getID());
+        const sectionBlock = blockBuilder.createSectionBlock({
+            text: `👋You are connected to Workspace **${workspaceName}**`,
+        });
+
+        await sendNotification(read, modify, user, room, {
+            blocks: [sectionBlock],
+        });
+        await roomInteraction.clearInteractionRoomId(user.id);
+
+        return this.success(OAuth2Content.success);
+    }
+}

--- a/src/helper/getAuthPageTemplate.ts
+++ b/src/helper/getAuthPageTemplate.ts
@@ -1,0 +1,61 @@
+export function getAuthPageTemplate(
+    title: string,
+    imgUrl: string,
+    message: string,
+    info: string
+) {
+    const template = ` 
+    <html>
+    <head>
+      <title>${title}</title>
+      <style>
+        body {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          height: 100vh;
+          margin: 0;
+          background-color: white;
+        }
+
+        .container {
+          text-align: center;
+        }
+
+        img {
+          max-width: 100%;
+          height: 40%;
+          display: block;
+          margin: 0 auto;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        <img src=${imgUrl} alt="Image" />
+        <p
+          style="
+            font-family: sans-serif;
+            font-size: x-large;
+            font-weight: lighter;
+          "
+        >
+        ${message}
+        </p>
+        <p
+          style="
+            font-family: sans-serif;
+            font-size: smaller;
+            color: #85888d;
+          "
+        >
+          ${info}
+        </p>
+      </div>
+    </body>
+    </html>
+    `;
+
+    return template;
+}

--- a/src/helper/getConnectBlock.ts
+++ b/src/helper/getConnectBlock.ts
@@ -1,0 +1,31 @@
+import { ButtonStyle } from "@rocket.chat/apps-engine/definition/uikit";
+import { Block } from "@rocket.chat/ui-kit";
+import { NotionApp } from "../../NotionApp";
+import { OAuth2Action, OAuth2Block } from "../../enum/OAuth2";
+
+export async function getConnectBlock(
+    app: NotionApp,
+    message: string,
+    url: string
+): Promise<Array<Block>> {
+    const { elementBuilder, blockBuilder } = app.getUtils();
+    const buttonElement = elementBuilder.addButton(
+        {
+            text: "Connect to Workspace",
+            style: ButtonStyle.PRIMARY,
+            url,
+        },
+        {
+            blockId: OAuth2Block.CONNECT_TO_WORKSPACE,
+            actionId: OAuth2Action.CONNECT_TO_WORKSPACE,
+        }
+    );
+    const actionBlock = blockBuilder.createActionBlock({
+        elements: [buttonElement],
+    });
+    const textBlock = blockBuilder.createSectionBlock({
+        text: message,
+    });
+
+    return [textBlock, actionBlock];
+}

--- a/src/helper/getConnectLayout.ts
+++ b/src/helper/getConnectLayout.ts
@@ -20,8 +20,11 @@ export function getConnectPreview(
         ? `${workspace_icon}`
         : undefined;
     const thumb = workspace_icon_url ? { url: workspace_icon_url } : undefined;
-    const title = [`[**${workspace_name}**](${Notion.WEBSITE_URL})`];
-    const description = ["**👋 You are Connected to Workspace**"];
+    const title = [
+        `**📚 [**${workspace_name}**](${Notion.WEBSITE_URL})**`,
+        "**👋 Connected to Workspace**",
+    ];
+    const description = [""];
     const avatarElement = elementBuilder.addImage({
         imageUrl: avatar_url as string,
         altText: name as string,

--- a/src/helper/getConnectLayout.ts
+++ b/src/helper/getConnectLayout.ts
@@ -1,0 +1,42 @@
+import { ITokenInfo } from "../../definition/authorization/IOAuth2Storage";
+import { PreviewBlockWithPreview, PreviewBlock } from "@rocket.chat/ui-kit";
+import { ElementBuilder } from "../lib/ElementBuilder";
+import { BlockBuilder } from "../lib/BlockBuilder";
+import { Notion } from "../../enum/Notion";
+
+export function getConnectPreview(
+    appId: string,
+    tokenInfo: ITokenInfo
+): Exclude<PreviewBlock, PreviewBlockWithPreview> {
+    const { workspace_name, workspace_icon, owner } = tokenInfo;
+    const { name, avatar_url } = owner.user;
+
+    const elementBuilder = new ElementBuilder(appId);
+    const blockBuilder = new BlockBuilder(appId);
+
+    const workspace_icon_url = workspace_icon?.startsWith("/")
+        ? `${Notion.WEBSITE_URL}${workspace_icon}`
+        : workspace_icon?.startsWith("http")
+        ? `${workspace_icon}`
+        : undefined;
+    const thumb = workspace_icon_url ? { url: workspace_icon_url } : undefined;
+    const title = [`[**${workspace_name}**](${Notion.WEBSITE_URL})`];
+    const description = ["**👋 You are Connected to Workspace**"];
+    const avatarElement = elementBuilder.addImage({
+        imageUrl: avatar_url as string,
+        altText: name as string,
+    });
+    const avatarName = `**${name}**`;
+    const footer = blockBuilder.createContextBlock({
+        contextElements: [avatarElement, avatarName],
+    });
+
+    const connectPreview = blockBuilder.createPreviewBlock({
+        title,
+        description,
+        footer,
+        thumb,
+    });
+
+    return connectPreview;
+}

--- a/src/helper/getCredential.ts
+++ b/src/helper/getCredential.ts
@@ -3,7 +3,7 @@ import { ICredential } from "../../definition/authorization/ICredential";
 import { OAuth2Setting } from "../../config/settings";
 import { ServerSetting } from "../../enum/Settings";
 
-async function getCredentials(read: IRead): Promise<ICredential> {
+export async function getCredentials(read: IRead): Promise<ICredential> {
     const clientId = (await read
         .getEnvironmentReader()
         .getSettings()
@@ -12,10 +12,14 @@ async function getCredentials(read: IRead): Promise<ICredential> {
         .getEnvironmentReader()
         .getSettings()
         .getValueById(OAuth2Setting.CLIENT_SECRET)) as string;
-    const siteUrl = (await read
+    let siteUrl = (await read
         .getEnvironmentReader()
         .getServerSettings()
         .getValueById(ServerSetting.SITE_URL)) as string;
+
+    if (siteUrl.endsWith("/")) {
+        siteUrl = siteUrl.substring(0, siteUrl.length - 1);
+    }
 
     return { clientId, clientSecret, siteUrl };
 }

--- a/src/helper/getCredential.ts
+++ b/src/helper/getCredential.ts
@@ -1,0 +1,21 @@
+import { IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { ICredential } from "../../definition/authorization/ICredential";
+import { OAuth2Setting } from "../../config/settings";
+import { ServerSetting } from "../../enum/Settings";
+
+async function getCredentials(read: IRead): Promise<ICredential> {
+    const clientId = (await read
+        .getEnvironmentReader()
+        .getSettings()
+        .getValueById(OAuth2Setting.CLIENT_ID)) as string;
+    const clientSecret = (await read
+        .getEnvironmentReader()
+        .getSettings()
+        .getValueById(OAuth2Setting.CLIENT_SECRET)) as string;
+    const siteUrl = (await read
+        .getEnvironmentReader()
+        .getServerSettings()
+        .getValueById(ServerSetting.SITE_URL)) as string;
+
+    return { clientId, clientSecret, siteUrl };
+}

--- a/src/helper/getCredential.ts
+++ b/src/helper/getCredential.ts
@@ -1,9 +1,17 @@
-import { IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { IModify, IRead } from "@rocket.chat/apps-engine/definition/accessors";
 import { ICredential } from "../../definition/authorization/ICredential";
 import { OAuth2Setting } from "../../config/settings";
 import { ServerSetting } from "../../enum/Settings";
+import { sendNotification } from "./message";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
 
-export async function getCredentials(read: IRead): Promise<ICredential> {
+export async function getCredentials(
+    read: IRead,
+    modify: IModify,
+    user: IUser,
+    room: IRoom
+): Promise<ICredential | null> {
     const clientId = (await read
         .getEnvironmentReader()
         .getSettings()
@@ -16,6 +24,30 @@ export async function getCredentials(read: IRead): Promise<ICredential> {
         .getEnvironmentReader()
         .getServerSettings()
         .getValueById(ServerSetting.SITE_URL)) as string;
+
+    if (
+        !(
+            clientId.trim().length &&
+            clientSecret.trim().length &&
+            siteUrl.trim().length
+        )
+    ) {
+        // based on user role send relevant notification
+        let message: string;
+        if (user.roles.includes(ServerSetting.USER_ROLE_ADMIN)) {
+            message = `Please Configure the App and Ensure the \`SiteUrl\` is correct in the Server Settings.
+            \xa0\xa0• Go to **NotionApp** Settings and add \`ClientId\` and \`ClientSecret\` Generated from a Notion Public Integration
+            `;
+        } else {
+            message = `🚫 Something Went Wrong, Please Contact the Admin!`;
+        }
+
+        await sendNotification(read, modify, user, room, {
+            message,
+        });
+
+        return null;
+    }
 
     if (siteUrl.endsWith("/")) {
         siteUrl = siteUrl.substring(0, siteUrl.length - 1);

--- a/src/helper/message.ts
+++ b/src/helper/message.ts
@@ -1,0 +1,28 @@
+import { IModify, IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { Block } from "@rocket.chat/ui-kit";
+
+export async function sendNotification(
+    read: IRead,
+    modify: IModify,
+    user: IUser,
+    room: IRoom,
+    content: { message?: string; blocks?: Array<Block> }
+): Promise<void> {
+    const appUser = (await read.getUserReader().getAppUser()) as IUser;
+    const { message, blocks } = content;
+    const messageBuilder = modify
+        .getCreator()
+        .startMessage()
+        .setSender(appUser)
+        .setRoom(room)
+        .setGroupable(false);
+
+    if (message) {
+        messageBuilder.setText(message);
+    } else if (blocks) {
+        messageBuilder.setBlocks(blocks);
+    }
+    return read.getNotifier().notifyUser(user, messageBuilder.getMessage());
+}

--- a/src/lib/BlockBuilder.ts
+++ b/src/lib/BlockBuilder.ts
@@ -1,0 +1,46 @@
+import { ActionBlockParam } from "../../definition/ui-kit/Block/IActionBlock";
+import { IBlockBuilder } from "../../definition/ui-kit/Block/IBlockBuilder";
+import { SectionBlockParam } from "../../definition/ui-kit/Block/ISectionBlock";
+import {
+    SectionBlock,
+    LayoutBlockType,
+    TextObjectType,
+    TextObject,
+    ActionsBlock,
+} from "@rocket.chat/ui-kit";
+
+export class BlockBuilder implements IBlockBuilder {
+    constructor(private readonly appId: string) {}
+    public createSectionBlock(param: SectionBlockParam): SectionBlock {
+        const { text, blockId, fields, accessory } = param;
+        const sectionBlock: SectionBlock = {
+            appId: this.appId,
+            blockId,
+            type: LayoutBlockType.SECTION,
+            text: {
+                type: TextObjectType.MRKDWN,
+                text: text ? text : "",
+            },
+            accessory,
+            fields: fields ? this.createFields(fields) : undefined,
+        };
+        return sectionBlock;
+    }
+    public createActionBlock(param: ActionBlockParam): ActionsBlock {
+        const { elements } = param;
+        const actionBlock: ActionsBlock = {
+            type: LayoutBlockType.ACTIONS,
+            elements: elements,
+        };
+        return actionBlock;
+    }
+
+    private createFields(fields: Array<string>): Array<TextObject> {
+        return fields.map((field) => {
+            return {
+                type: TextObjectType.MRKDWN,
+                text: field,
+            };
+        });
+    }
+}

--- a/src/lib/BlockBuilder.ts
+++ b/src/lib/BlockBuilder.ts
@@ -1,5 +1,7 @@
 import { ActionBlockParam } from "../../definition/ui-kit/Block/IActionBlock";
 import { IBlockBuilder } from "../../definition/ui-kit/Block/IBlockBuilder";
+import { ContextBlockParam } from "../../definition/ui-kit/Block/IContextBlock";
+import { PreviewBlockParam } from "../../definition/ui-kit/Block/IPreviewBlock";
 import { SectionBlockParam } from "../../definition/ui-kit/Block/ISectionBlock";
 import {
     SectionBlock,
@@ -7,6 +9,9 @@ import {
     TextObjectType,
     TextObject,
     ActionsBlock,
+    PreviewBlockBase,
+    PreviewBlockWithThumb,
+    ContextBlock,
 } from "@rocket.chat/ui-kit";
 
 export class BlockBuilder implements IBlockBuilder {
@@ -22,7 +27,7 @@ export class BlockBuilder implements IBlockBuilder {
                 text: text ? text : "",
             },
             accessory,
-            fields: fields ? this.createFields(fields) : undefined,
+            fields: fields ? this.createTextObjects(fields) : undefined,
         };
         return sectionBlock;
     }
@@ -35,12 +40,50 @@ export class BlockBuilder implements IBlockBuilder {
         return actionBlock;
     }
 
-    private createFields(fields: Array<string>): Array<TextObject> {
+    private createTextObjects(fields: Array<string>): Array<TextObject> {
         return fields.map((field) => {
             return {
                 type: TextObjectType.MRKDWN,
                 text: field,
             };
         });
+    }
+
+    public createPreviewBlock(
+        param: PreviewBlockParam
+    ): PreviewBlockBase | PreviewBlockWithThumb {
+        const { title, description, footer, thumb } = param;
+        const previewBlock: PreviewBlockBase | PreviewBlockWithThumb = {
+            type: LayoutBlockType.PREVIEW,
+            title: this.createTextObjects(title),
+            description: this.createTextObjects(description),
+            footer,
+            thumb,
+        };
+
+        return previewBlock;
+    }
+
+    public createContextBlock(param: ContextBlockParam): ContextBlock {
+        const { contextElements, blockId } = param;
+
+        const elements = contextElements.map((element) => {
+            if (typeof element === "string") {
+                return {
+                    type: TextObjectType.MRKDWN,
+                    text: element,
+                } as TextObject;
+            } else {
+                return element;
+            }
+        });
+
+        const contextBlock: ContextBlock = {
+            type: LayoutBlockType.CONTEXT,
+            elements,
+            blockId,
+        };
+
+        return contextBlock;
     }
 }

--- a/src/lib/ElementBuilder.ts
+++ b/src/lib/ElementBuilder.ts
@@ -1,0 +1,35 @@
+import {
+    ElementInteractionParam,
+    IElementBuilder,
+} from "../../definition/ui-kit/Element/IElementBuilder";
+import {
+    ButtonElement,
+    BlockElementType,
+    TextObjectType,
+} from "@rocket.chat/ui-kit";
+import { ButtonParam } from "../../definition/ui-kit/Element/IButtonElement";
+
+export class ElementBuilder implements IElementBuilder {
+    constructor(private readonly appId: string) {}
+    public addButton(
+        param: ButtonParam,
+        interaction: ElementInteractionParam
+    ): ButtonElement {
+        const { text, url, value, style } = param;
+        const { blockId, actionId } = interaction;
+        const button: ButtonElement = {
+            type: BlockElementType.BUTTON,
+            text: {
+                type: TextObjectType.PLAIN_TEXT,
+                text,
+            },
+            appId: this.appId,
+            blockId,
+            actionId,
+            url,
+            value,
+            style,
+        };
+        return button;
+    }
+}

--- a/src/lib/ElementBuilder.ts
+++ b/src/lib/ElementBuilder.ts
@@ -6,8 +6,10 @@ import {
     ButtonElement,
     BlockElementType,
     TextObjectType,
+    ImageElement,
 } from "@rocket.chat/ui-kit";
 import { ButtonParam } from "../../definition/ui-kit/Element/IButtonElement";
+import { ImageParam } from "../../definition/ui-kit/Element/IImageElement";
 
 export class ElementBuilder implements IElementBuilder {
     constructor(private readonly appId: string) {}
@@ -32,4 +34,15 @@ export class ElementBuilder implements IElementBuilder {
         };
         return button;
     }
+
+    public addImage(param: ImageParam): ImageElement {
+        const { imageUrl, altText } = param;
+        const image: ImageElement = {
+            type: BlockElementType.IMAGE,
+            imageUrl,
+            altText,
+        };
+        return image;
+    }
+    
 }

--- a/src/lib/NotionSDK.ts
+++ b/src/lib/NotionSDK.ts
@@ -1,0 +1,69 @@
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { INotionSDK } from "../../definition/lib/INotion";
+import { IHttp, IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { URL } from "url";
+import { ITokenInfo } from "../../definition/authorization/IOAuth2Storage";
+import { ClientError } from "../../errors/Error";
+import { NotionApi } from "../../enum/Notion";
+import { OAuth2Credential, OAuth2Locator } from "../../enum/OAuth2";
+import { AppsEngineException } from "@rocket.chat/apps-engine/definition/exceptions";
+import { getCredentials } from "../helper/getCredential";
+
+export class NotionSDK implements INotionSDK {
+    baseUrl: string;
+    NotionVersion: string;
+    constructor() {
+        this.baseUrl = NotionApi.BASE_URL;
+        this.NotionVersion = NotionApi.VERSION;
+    }
+    public async getAuthorizationUrl(
+        user: IUser,
+        read: IRead
+    ): Promise<string> {
+        const userId = user.id;
+        const { clientId, siteUrl } = await getCredentials(read);
+
+        const redirectUrl = new URL(OAuth2Locator.redirectUrlPath, siteUrl);
+        const authorizationUrl = new URL(OAuth2Locator.authUri);
+        authorizationUrl.searchParams.set(OAuth2Credential.CLIENT_ID, clientId);
+        authorizationUrl.searchParams.set(
+            OAuth2Credential.REDIRECT_URI,
+            redirectUrl.toString()
+        );
+        authorizationUrl.searchParams.set(OAuth2Credential.STATE, userId);
+
+        return authorizationUrl.toString();
+    }
+
+    public async createToken(
+        http: IHttp,
+        redirectUrl: URL,
+        code: string,
+        credentials: string
+    ): Promise<ITokenInfo | ClientError> {
+        try {
+            const response = await http.post(OAuth2Locator.accessTokenUrl, {
+                data: {
+                    grant_type: OAuth2Credential.GRANT_TYPE,
+                    redirect_uri: redirectUrl.toString(),
+                    code,
+                },
+                headers: {
+                    Authorization: `Basic ${credentials}`,
+                    "Content-Type": NotionApi.CONTENT_TYPE,
+                    "User-Agent": NotionApi.USER_AGENT,
+                },
+            });
+
+            if (!response.statusCode.toString().startsWith("2")) {
+                return new ClientError(
+                    `Error while Creating token: ${response.statusCode}`,
+                    response.content
+                );
+            }
+            return response.data as ITokenInfo;
+        } catch (err) {
+            throw new AppsEngineException(err as string);
+        }
+    }
+}

--- a/src/lib/NotionSDK.ts
+++ b/src/lib/NotionSDK.ts
@@ -10,19 +10,20 @@ import { AppsEngineException } from "@rocket.chat/apps-engine/definition/excepti
 export class NotionSDK implements INotionSDK {
     baseUrl: string;
     NotionVersion: string;
-    constructor() {
+    http: IHttp;
+    constructor(http: IHttp) {
         this.baseUrl = NotionApi.BASE_URL;
         this.NotionVersion = NotionApi.VERSION;
+        this.http = http;
     }
 
     public async createToken(
-        http: IHttp,
         redirectUrl: URL,
         code: string,
         credentials: string
     ): Promise<ITokenInfo | ClientError> {
         try {
-            const response = await http.post(OAuth2Locator.accessTokenUrl, {
+            const response = await this.http.post(OAuth2Locator.accessTokenUrl, {
                 data: {
                     grant_type: OAuth2Credential.GRANT_TYPE,
                     redirect_uri: redirectUrl.toString(),

--- a/src/lib/NotionSDK.ts
+++ b/src/lib/NotionSDK.ts
@@ -1,13 +1,11 @@
-import { IUser } from "@rocket.chat/apps-engine/definition/users";
 import { INotionSDK } from "../../definition/lib/INotion";
-import { IHttp, IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { IHttp } from "@rocket.chat/apps-engine/definition/accessors";
 import { URL } from "url";
 import { ITokenInfo } from "../../definition/authorization/IOAuth2Storage";
 import { ClientError } from "../../errors/Error";
 import { NotionApi } from "../../enum/Notion";
 import { OAuth2Credential, OAuth2Locator } from "../../enum/OAuth2";
 import { AppsEngineException } from "@rocket.chat/apps-engine/definition/exceptions";
-import { getCredentials } from "../helper/getCredential";
 
 export class NotionSDK implements INotionSDK {
     baseUrl: string;
@@ -15,24 +13,6 @@ export class NotionSDK implements INotionSDK {
     constructor() {
         this.baseUrl = NotionApi.BASE_URL;
         this.NotionVersion = NotionApi.VERSION;
-    }
-    public async getAuthorizationUrl(
-        user: IUser,
-        read: IRead
-    ): Promise<string> {
-        const userId = user.id;
-        const { clientId, siteUrl } = await getCredentials(read);
-
-        const redirectUrl = new URL(OAuth2Locator.redirectUrlPath, siteUrl);
-        const authorizationUrl = new URL(OAuth2Locator.authUri);
-        authorizationUrl.searchParams.set(OAuth2Credential.CLIENT_ID, clientId);
-        authorizationUrl.searchParams.set(
-            OAuth2Credential.REDIRECT_URI,
-            redirectUrl.toString()
-        );
-        authorizationUrl.searchParams.set(OAuth2Credential.STATE, userId);
-
-        return authorizationUrl.toString();
     }
 
     public async createToken(

--- a/src/storage/RoomInteraction.ts
+++ b/src/storage/RoomInteraction.ts
@@ -1,0 +1,49 @@
+import {
+    RocketChatAssociationModel,
+    RocketChatAssociationRecord,
+} from "@rocket.chat/apps-engine/definition/metadata";
+import { IRoomInteractionStorage } from "../../definition/lib/IRoomInteraction";
+import {
+    IPersistence,
+    IPersistenceRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+
+export class RoomInteractionStorage implements IRoomInteractionStorage {
+    constructor(
+        private readonly persistence: IPersistence,
+        private readonly persistenceRead: IPersistenceRead
+    ) {}
+    public async storeInteractionRoomId(
+        userId: string,
+        roomId: string
+    ): Promise<void> {
+        const association = new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            `${userId}#RoomId`
+        );
+        await this.persistence.updateByAssociation(
+            association,
+            { roomId: roomId },
+            true
+        );
+    }
+
+    public async getInteractionRoomId(userId: string): Promise<string> {
+        const association = new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            `${userId}#RoomId`
+        );
+        const [result] = (await this.persistenceRead.readByAssociation(
+            association
+        )) as Array<{ roomId: string }>;
+        return result.roomId;
+    }
+
+    public async clearInteractionRoomId(userId: string): Promise<void> {
+        const association = new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            `${userId}#RoomId`
+        );
+        await this.persistence.removeByAssociation(association);
+    }
+}


### PR DESCRIPTION
## Issue(s) 
- Closes #4 
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criterias required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteriasd are provided -->

- [x] Create Setting for Credentials (SettingType STRING - ClientId, SettingType PASSWORD Client Secret).
- [x] Register Command with params connect and disconnect.
- [x] Create NotionSDK Class
- [x] Create WebHookEndpoint for handling Notion Callback
- [x] Create Function to getTokenInfo else Send Relevant Notification with Connect to Workspace button alerting user not connected.
- [x] Send Relevant Notification to Channel including Message from MessageBuilder when there is complete execution.
- [x] Create MessageBuilder with Button (only in case of connect)

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->


## Further comments
- [x]  Create CustomError Class extending which have CommonError class
- [x] Use Integration SVG in Authorization HTML page.
- [x] Handle Empty Credentials and give Notification to channel as per user Roles.
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
## Edge Cases

- [x] When User Changes State in AuthURL
- [x] When User Leaves in Between Auth
- [x] When User Cancel the Auth but Go Back to AuthURL pressing <— in Browser
- [x] When User runs connect command in two channels [Say first and Second] one by one during session and connects from First Message should go to First and so on.
- [x] When There is Problem from Notion Provider to Generate Token
- [x] Using feat with multiple user.
- [x] Handle Empty Credentials and give Notification to channel as per user Roles.