### PR TITLE
[Feat] Provide Helper Message on `/notion help` having Commands as Attachment

### DIFF
--- a/enum/CommandParam.ts
+++ b/enum/CommandParam.ts
@@ -2,6 +2,7 @@ export enum CommandParam {
     CONNECT = "connect",
     DISCONNECT = "disconnect",
     CREATE = "create",
+    HELP = "help",
 }
 
 export enum SubCommandParam {

--- a/enum/messages.ts
+++ b/enum/messages.ts
@@ -1,0 +1,7 @@
+export enum Messages {
+    HELPER_COMMANDS = `• use \`/notion connect\` to connect your workspace   
+        • use \`/notion disconnect\` to disconnect workspace   
+        • use \`/notion create database\` to create database
+        `,
+    HELPER_TEXT = `:wave: Need some help with \`/notion\`?`,
+}

--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -13,6 +13,7 @@ import {
 } from "../../definition/command/ICommandUtility";
 import { CommandParam, SubCommandParam } from "../../enum/CommandParam";
 import { Handler } from "../handlers/Handler";
+import { sendHelperNotification } from "../helper/message";
 
 export class CommandUtility implements ICommandUtility {
     public app: NotionApp;
@@ -53,6 +54,12 @@ export class CommandUtility implements ICommandUtility {
         });
         switch (this.params.length) {
             case 0: {
+                await sendHelperNotification(
+                    this.read,
+                    this.modify,
+                    this.sender,
+                    this.room
+                );
                 break;
             }
             case 1: {
@@ -61,8 +68,15 @@ export class CommandUtility implements ICommandUtility {
             }
             case 2: {
                 await this.handleDualParam(handler);
+                break;
             }
             default: {
+                await sendHelperNotification(
+                    this.read,
+                    this.modify,
+                    this.sender,
+                    this.room
+                );
             }
         }
     }
@@ -92,7 +106,15 @@ export class CommandUtility implements ICommandUtility {
                 );
                 break;
             }
+            case CommandParam.HELP:
             default: {
+                await sendHelperNotification(
+                    this.read,
+                    this.modify,
+                    this.sender,
+                    this.room
+                );
+                break;
             }
         }
     }
@@ -105,9 +127,21 @@ export class CommandUtility implements ICommandUtility {
                     await handler.createNotionDatabase();
                     return;
                 }
+                await sendHelperNotification(
+                    this.read,
+                    this.modify,
+                    this.sender,
+                    this.room
+                );
                 break;
             }
             default: {
+                await sendHelperNotification(
+                    this.read,
+                    this.modify,
+                    this.sender,
+                    this.room
+                );
                 break;
             }
         }

--- a/src/helper/message.ts
+++ b/src/helper/message.ts
@@ -6,6 +6,8 @@ import { NotionApp } from "../../NotionApp";
 import { OAuth2Content } from "../../enum/OAuth2";
 import { getConnectBlock } from "./getConnectBlock";
 import { IMessageAttachmentField } from "@rocket.chat/apps-engine/definition/messages";
+import { Messages } from "../../enum/messages";
+import { IMessageAttachment } from "@rocket.chat/apps-engine/definition/messages";
 
 export async function sendNotification(
     read: IRead,
@@ -88,4 +90,28 @@ export async function sendNotificationWithAttachments(
     ]);
 
     return read.getNotifier().notifyUser(user, messageBuilder.getMessage());
+}
+
+export async function sendHelperNotification(
+    read: IRead,
+    modify: IModify,
+    user: IUser,
+    room: IRoom
+): Promise<void> {
+    const appUser = (await read.getUserReader().getAppUser()) as IUser;
+    const attachment: IMessageAttachment = {
+        color: "#000000",
+        text: Messages.HELPER_COMMANDS,
+    };
+
+    const helperMessage = modify
+        .getCreator()
+        .startMessage()
+        .setRoom(room)
+        .setSender(appUser)
+        .setText(Messages.HELPER_TEXT)
+        .setAttachments([attachment])
+        .setGroupable(false);
+
+    return read.getNotifier().notifyUser(user, helperMessage.getMessage());
 }


### PR DESCRIPTION
## Issue(s) 

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->
- Closes #7 
## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criterias required by the Pull Request in order to close the issue. This Section can be deleted if no acceptance criteriasd are provided -->

- [x]  Register help param
- [x] add Command Text as Attachment
- [x] Message in Room should be visible to Only command executor

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

![HelperMessage](https://github.com/RocketChat/Apps.Notion/assets/65061890/c990ec2c-e9e6-494e-a0ed-b0d55f88be9f)

## Further comments


<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->