### PR TITLE
[ Fix ] Title Input Visibility When Nothing is Selected in Select Page Dropdown

### DIFF
--- a/src/handlers/ExecuteBlockActionHandler.ts
+++ b/src/handlers/ExecuteBlockActionHandler.ts
@@ -873,11 +873,33 @@ export class ExecuteBlockActionHandler {
         let Object: IPage | IDatabase = JSON.parse(value);
         let parentObject: IParentPage | IParentDatabase = Object.parent;
 
-        // update the modal if database is selected
-        if (parentObject.type.includes(NotionObjectTypes.PAGE_ID)) {
-            return this.context.getInteractionResponder().successResponse();
-        }
 
+        if (parentObject.type.includes(NotionObjectTypes.PAGE_ID)) {
+            const page = Object as IPage;
+            const modal = await createPageOrRecordModal(
+                this.app,
+                user,
+                this.read,
+                this.persistence,
+                this.modify,
+                room,
+                modalInteraction,
+                tokenInfo,
+                undefined,
+                page
+            );
+
+            if (modal instanceof Error) {
+                this.app.getLogger().error(modal.message);
+                return this.context.getInteractionResponder().errorResponse();
+            }
+
+            return this.context
+                .getInteractionResponder()
+                .updateModalViewResponse(modal);
+        }
+        
+        // update the modal if database is selected
         const database = Object as IDatabase;
 
         const databaseId = database.parent.database_id;

--- a/src/modals/createPageOrRecordModal.ts
+++ b/src/modals/createPageOrRecordModal.ts
@@ -42,7 +42,7 @@ export async function createPageOrRecordModal(
     modalInteraction: ModalInteractionStorage,
     tokenInfo: ITokenInfo,
     parent?: IDatabase,
-    page?:IPage,
+    page?: IPage,
     addPropertyAction?: boolean
 ): Promise<IUIKitSurfaceViewParam | Error> {
     const { elementBuilder, blockBuilder } = app.getUtils();
@@ -140,6 +140,7 @@ export async function createPageOrRecordModal(
             actionId: NotionPageOrRecord.TITLE_ACTION,
         }
     );
+
     if(page || parent) blocks.push(titleOfPageOrRecordBlock);
 
     if (parent && addedProperty) {

--- a/src/modals/createPageOrRecordModal.ts
+++ b/src/modals/createPageOrRecordModal.ts
@@ -23,7 +23,7 @@ import { SearchPageAndDatabase } from "../../enum/modals/common/SearchPageAndDat
 import { DatabaseModal } from "../../enum/modals/NotionDatabase";
 import { OverflowMenuComponent } from "./common/OverflowMenuComponent";
 import { Modals } from "../../enum/modals/common/Modals";
-import { IDatabase } from "../../definition/lib/INotion";
+import { IDatabase, IPage } from "../../definition/lib/INotion";
 import { getSelectDatabaseLayout } from "../helper/getSelectDatabaseLayout";
 import { getTitleProperty } from "../helper/getTitleProperty";
 import { ButtonInSectionComponent } from "./common/buttonInSectionComponent";
@@ -42,6 +42,7 @@ export async function createPageOrRecordModal(
     modalInteraction: ModalInteractionStorage,
     tokenInfo: ITokenInfo,
     parent?: IDatabase,
+    page?:IPage,
     addPropertyAction?: boolean
 ): Promise<IUIKitSurfaceViewParam | Error> {
     const { elementBuilder, blockBuilder } = app.getUtils();
@@ -139,8 +140,7 @@ export async function createPageOrRecordModal(
             actionId: NotionPageOrRecord.TITLE_ACTION,
         }
     );
-
-    blocks.push(titleOfPageOrRecordBlock);
+    if(page || parent) blocks.push(titleOfPageOrRecordBlock);
 
     if (parent && addedProperty) {
         const data = addedProperty.data;


### PR DESCRIPTION
## Issue(s)
Fixed the title input visibility issue; now it will be visible only when a page or database is selected (In the database, additional fetching happens, and that is left as it is).

<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

Closes #52 

## Acceptance Criteria fulfillment

<!-- This will contain the acceptance criteria required by the Pull Request to close the issue. This Section can be deleted if no acceptance criterias are provided -->

- [x] Identified that the title block is rendered without any condition.
- [x] Added an optional page argument, and the title block will be rendered only when a page or database is selected.
- [x] Updated the modal when a page gets selected, similar to how it was implemented when a database is selected.

## Proposed changes (including videos or screenshots)

[Demo Video Link](https://github.com/RocketChat/Apps.Notion/assets/78961432/7b557725-c647-41ed-85f2-038bd8160667)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->