### PR TITLE
Fix: Unable to connect Notion Workspace properly

### DIFF
--- a/src/helper/getConnectLayout.ts
+++ b/src/helper/getConnectLayout.ts
@@ -3,6 +3,7 @@ import { PreviewBlockWithPreview, PreviewBlock } from "@rocket.chat/ui-kit";
 import { ElementBuilder } from "../lib/ElementBuilder";
 import { BlockBuilder } from "../lib/BlockBuilder";
 import { Notion } from "../../enum/Notion";
+import { OnInstallContent } from "../../enum/messages";
 
 export function getConnectPreview(
     appId: string,
@@ -17,14 +18,16 @@ export function getConnectPreview(
     const workspace_icon_url = workspace_icon?.startsWith("/")
         ? `${Notion.WEBSITE_URL}${workspace_icon}`
         : workspace_icon?.startsWith("http")
-        ? `${workspace_icon}`
-        : undefined;
-    const thumb = workspace_icon_url ? { url: workspace_icon_url } : undefined;
-    const title = [
-        `** [**${workspace_name}**](${Notion.WEBSITE_URL})**`,
-        "**Connected to Workspace**",
+          ? `${workspace_icon}`
+          : undefined;
+    const thumb = workspace_icon_url
+        ? { url: workspace_icon_url }
+        : { url: OnInstallContent.PREVIEW_IMAGE.toString() };
+    const title = [""];
+    const description = [
+        `** [${workspace_name}](${Notion.WEBSITE_URL})**`,
+        "**Connected to Workspace** \n",
     ];
-    const description = [""];
     const avatarElement = elementBuilder.addImage({
         imageUrl: avatar_url as string,
         altText: name as string,


### PR DESCRIPTION
## Issue(s) 

- Fixes : #81 

## Acceptance Criteria fulfillment

Fixed a crash in the Rocket.Chat Client caused by a missing workspace icon in Notion, which was passed to the PreviewBlock. Added Notion's default icon in the PreviewBlock to ensure stability.

## Proposed changes (including videos or screenshots)

[Screencast from 10-02-25 07:23:12 PM IST.webm](https://github.com/user-attachments/assets/5a8ce528-b01a-4439-bd48-1ade14f45c96)
